### PR TITLE
Fix layout toggle on alert status page

### DIFF
--- a/alerts/alert_matrix.html
+++ b/alerts/alert_matrix.html
@@ -169,7 +169,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container-fluid">
+<div id="alertMatrixContainer">
   <!-- Alert Matrix Card -->
   <div class="card" style="border: 1px solid {{ theme.get('border_color', '#ccc') }};">
     <div class="card-header" style="background-color: {{ theme.get('card_header_color', '#007bff') }}; color: {{ theme.get('card_header_text_color', '#fff') }}; position: relative;">


### PR DESCRIPTION
## Summary
- ensure the alert matrix container responds to layout toggle

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*