### PR TITLE
Add Hedge Report link to nav

### DIFF
--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -143,7 +143,12 @@
             </a>
           </li>
           <li class="nav-item">
-            <a href="{{ url_for('sonic_labs.hedge_calculator') }}" class="nav-link">
+            <a href="{{ url_for('sonic_labs.hedge_calculator') }}" class="nav-link" title="Hedge Calculator">
+              <span class="hedgehog-icon" style="font-size:1.2em;">🦔</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="{{ url_for('positions.heat_report') }}" class="nav-link" title="Hedge Report">
               <span class="hedgehog-icon" style="font-size:1.2em;">🦔</span>
             </a>
           </li>


### PR DESCRIPTION
## Summary
- add a hedgehog icon link to the Hedge Report page in the title bar

## Testing
- `pytest -k nothing` *(fails: ModuleNotFoundError: No module named 'selenium')*