### PR TITLE
Add GPT domain core

### DIFF
--- a/gpt/gpt_bp.py
+++ b/gpt/gpt_bp.py
@@ -1,0 +1,18 @@
+import logging
+from flask import Blueprint, jsonify, request
+
+from .gpt_core import GPTCore
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+gpt_bp = Blueprint('gpt_bp', __name__)
+
+
+@gpt_bp.route('/gpt/analyze', methods=['POST'])
+def analyze():
+    """Endpoint to analyze portfolio data with GPT."""
+    instructions = request.json.get('prompt', '') if request.is_json else ''
+    core = GPTCore()
+    result = core.analyze(instructions)
+    return jsonify({"reply": result})

--- a/gpt/gpt_core.py
+++ b/gpt/gpt_core.py
@@ -1,0 +1,86 @@
+import os
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from data.data_locker import DataLocker
+from config.config_constants import DB_PATH
+
+
+class GPTCore:
+    """Core utilities for interacting with GPT."""
+
+    def __init__(self, db_path: str = DB_PATH):
+        load_dotenv()
+        self.logger = logging.getLogger(__name__)
+        self.data_locker = DataLocker.get_instance(db_path)
+        self.client = OpenAI(api_key=os.getenv("OPEN_AI_KEY"))
+
+    def _fetch_snapshots(self) -> Dict[str, Optional[dict]]:
+        current = self.data_locker.get_latest_portfolio_snapshot()
+        history = self.data_locker.get_portfolio_history()
+        previous = history[-2] if len(history) >= 2 else None
+        return {"current": current, "previous": previous}
+
+    def build_payload(self, instructions: str = "") -> Dict[str, Any]:
+        snaps = self._fetch_snapshots()
+        payload = {
+            "type": "gpt_analysis_bundle",
+            "version": "1.0",
+            "generated": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "meta": {
+                "type": "meta",
+                "version": "1.0",
+                "owner": "Geno",
+                "strategy": "hedged, automated trading",
+                "goal": "optimize exposure while minimizing risk",
+                "notes": "Background context",
+            },
+            "definitions": {
+                "type": "definitions",
+                "metrics": {
+                    "travel_percent": "Defines change from entry to current price",
+                    "heat_index": "Composite risk metric",
+                },
+            },
+            "alert_limits": {
+                "alert_ranges": {
+                    "heat_index_ranges": {
+                        "enabled": True,
+                        "low": 7.0,
+                        "medium": 33.0,
+                        "high": 66.0,
+                    }
+                }
+            },
+            "module_references": {
+                "modules": {
+                    "PositionCore": {"role": "Manages enrichment, snapshots, sync"},
+                    "HedgeCalcServices": {"role": "Suggests hedge rebalancing"},
+                }
+            },
+            "current_snapshot": snaps.get("current"),
+            "previous_snapshot": snaps.get("previous"),
+            "instructions_for_ai": instructions or "Analyze portfolio risk and improvements",
+        }
+        return payload
+
+    def analyze(self, instructions: str = "") -> str:
+        payload = self.build_payload(instructions)
+        self.logger.debug("Sending payload to GPT")
+        messages = [
+            {"role": "system", "content": "You are a portfolio analysis assistant."},
+            {"role": "user", "content": json.dumps(payload)},
+        ]
+        try:
+            response = self.client.chat.completions.create(model="gpt-3.5-turbo", messages=messages)
+            reply = response.choices[0].message.content.strip()
+            self.logger.debug("Received reply from GPT")
+            return reply
+        except Exception as e:
+            self.logger.exception(f"GPT analysis failed: {e}")
+            return f"Error: {e}"

--- a/gpt_core_spec.md
+++ b/gpt_core_spec.md
@@ -1,0 +1,126 @@
+# 📘 GPT Input Specification — Modular Portfolio Analysis
+**Version:** 1.0  
+**Generated:** 2025-05-26 20:08:36  
+**Author:** Geno
+
+---
+
+## 🎯 Purpose
+This specification defines the modular JSON format for sending portfolio, alert, and analysis context to GPT. It allows structured evaluation of risk, hedging, and performance.
+
+---
+
+## 🧩 Top-Level File: `gpt_response_wrapper.json`
+Acts as the main bundle reference.
+```json
+{
+  "type": "gpt_analysis_bundle",
+  "version": "1.0",
+  "generated": "YYYY-MM-DDTHH:MM:SSZ",
+  "meta_file": "gpt_meta_input.json",
+  "definitions_file": "gpt_definitions_input.json",
+  "alert_limits_file": "gpt_alert_limits_input.json",
+  "module_reference_file": "gpt_module_references.json",
+  "current_snapshot_file": "snapshot_<DATE>.json",
+  "previous_snapshot_file": "snapshot_<DATE>.json",
+  "instructions_for_ai": "Prompt for GPT's use"
+}
+```
+
+---
+
+## 📁 Referenced Files
+
+### 🧠 `gpt_meta_input.json`
+```json
+{
+  "type": "meta",
+  "version": "1.0",
+  "owner": "Geno",
+  "strategy": "hedged, automated trading",
+  "goal": "optimize exposure while minimizing risk",
+  "notes": "Background context"
+}
+```
+
+### 🧾 `gpt_definitions_input.json`
+```json
+{
+  "type": "definitions",
+  "metrics": {
+    "travel_percent": "Defines change from entry to current price",
+    "heat_index": "Composite risk metric"
+  }
+}
+```
+
+### 🚨 `gpt_alert_limits_input.json`
+```json
+{
+  "alert_ranges": {
+    "heat_index_ranges": {
+      "enabled": true,
+      "low": 7.0,
+      "medium": 33.0,
+      "high": 66.0
+    }
+  }
+}
+```
+
+### 🧠 `gpt_module_references.json`
+```json
+{
+  "modules": {
+    "PositionCore": {
+      "role": "Manages enrichment, snapshots, sync"
+    },
+    "HedgeCalcServices": {
+      "role": "Suggests hedge rebalancing"
+    }
+  }
+}
+```
+
+### 📦 `snapshot_<DATE>.json`
+Includes:
+- `totals`: aggregate metrics
+- `positions`: list of full position objects
+
+```json
+{
+  "positions": [
+    {
+      "id": "...",
+      "asset_type": "BTC",
+      "position_type": "LONG",
+      "leverage": 5.0,
+      "travel_percent": -12.4
+    }
+  ]
+}
+```
+
+---
+
+## 🧠 GPT Behavior
+
+GPT will:
+- Analyze differences between snapshots
+- Compare metrics to thresholds
+- Identify alert violations
+- Recommend improvements (rebalance, de-risk)
+
+---
+
+## ✅ Required Files Summary
+
+| File                        | Required | Description                        |
+|-----------------------------|----------|------------------------------------|
+| gpt_response_wrapper.json   | ✅       | Master bundle and routing          |
+| gpt_meta_input.json         | ✅       | Strategy and owner intent          |
+| gpt_definitions_input.json  | ✅       | Metric definitions                 |
+| gpt_alert_limits_input.json | ✅       | Alert configuration thresholds     |
+| gpt_module_references.json  | ✅       | Module behaviors and descriptions  |
+| snapshot_<date>.json        | ✅       | Portfolio states (prev + current)  |
+


### PR DESCRIPTION
## Summary
- create GPT domain specification
- implement `GPTCore` to package data for GPT and send to OpenAI
- add Flask blueprint to expose `/gpt/analyze`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*